### PR TITLE
Support Python >= 3.8 & fix parameters

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -21,7 +21,7 @@ jobs:
         config:
           - { os: ubuntu-latest, pip: ~/.cache/pip }
           - { os: macos-latest, pip: ~/Library/Caches/pip }
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10"]
     name: "${{ matrix.config.os }} Python ${{ matrix.python }}"
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Note that FISTA also requires $f$ to be convex.
 - Documentation: https://zalgo3.github.io/zfista/
 
 ## Requirements
-- Python 3.7 or later
+- Python 3.8 or later
 
 ## Install
 ```sh

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -303,6 +303,7 @@ def benchmark(
     high: Union[float, np.ndarray],
     n_samples: int = 100,
     overwrite: bool = False,
+    max_iter: int = 10000000,
     verbose: bool = False,
 ) -> Tuple[List[OptimizeResult], List[OptimizeResult], List[OptimizeResult]]:
     directory = create_directory(problem, experiment_name)
@@ -318,7 +319,7 @@ def benchmark(
             overwrite,
             lambda: Parallel(n_jobs=-1)(
                 delayed(problem.minimize_proximal_gradient)(
-                    x0, return_all=True, verbose=verbose
+                    x0, return_all=True, max_iter=max_iter, verbose=verbose
                 )
                 for x0 in initial_points
             ),
@@ -330,7 +331,11 @@ def benchmark(
             overwrite,
             lambda: Parallel(n_jobs=-1)(
                 delayed(problem.minimize_proximal_gradient)(
-                    x0, nesterov=True, return_all=True, verbose=verbose
+                    x0,
+                    nesterov=True,
+                    return_all=True,
+                    max_iter=max_iter,
+                    verbose=verbose,
                 )
                 for x0 in initial_points
             ),
@@ -344,7 +349,12 @@ def benchmark(
             overwrite,
             lambda: Parallel(n_jobs=-1)(
                 delayed(problem.minimize_proximal_gradient)(
-                    x0, nesterov=True, return_all=True, deprecated=True, verbose=verbose
+                    x0,
+                    nesterov=True,
+                    return_all=True,
+                    deprecated=True,
+                    max_iter=max_iter,
+                    verbose=verbose,
                 )
                 for x0 in initial_points
             ),

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -303,7 +303,7 @@ def benchmark(
     high: Union[float, np.ndarray],
     n_samples: int = 100,
     overwrite: bool = False,
-    max_iter: int = 10000000,
+    max_iter: int = 100000000,
     verbose: bool = False,
 ) -> Tuple[List[OptimizeResult], List[OptimizeResult], List[OptimizeResult]]:
     directory = create_directory(problem, experiment_name)
@@ -319,7 +319,11 @@ def benchmark(
             overwrite,
             lambda: Parallel(n_jobs=-1)(
                 delayed(problem.minimize_proximal_gradient)(
-                    x0, return_all=True, max_iter=max_iter, verbose=verbose
+                    x0,
+                    return_all=True,
+                    max_iter=max_iter,
+                    max_iter_internal=max_iter,
+                    verbose=verbose,
                 )
                 for x0 in initial_points
             ),
@@ -335,6 +339,7 @@ def benchmark(
                     nesterov=True,
                     return_all=True,
                     max_iter=max_iter,
+                    max_iter_internal=max_iter,
                     verbose=verbose,
                 )
                 for x0 in initial_points
@@ -354,6 +359,7 @@ def benchmark(
                     return_all=True,
                     deprecated=True,
                     max_iter=max_iter,
+                    max_iter_internal=max_iter,
                     verbose=verbose,
                 )
                 for x0 in initial_points

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ install_requires =
     pymoo
     scipy
     typing_extensions
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Python 3.7 will be EOL on 06/27/2023 and the latest version of scipy is no longer supported, so it will also be removed from zfista support